### PR TITLE
Update PCSX ReARMed core and default config

### DIFF
--- a/frontend/source/core_spec/defines.cpp
+++ b/frontend/source/core_spec/defines.cpp
@@ -691,14 +691,7 @@ const std::vector<std::pair<const char *, const char *>> DEFAULT_CORE_SETTINGS =
 #elif defined(KM_MAME2003_XTREME_AMPED_BUILD)
     {"mame2003-xtreme-amped-rstick_to_btns", "disabled"}
 #elif defined(PCSX_REARMED_BUILD)
-    {"pcsx_rearmed_bios", "HLE"},
     {"pcsx_rearmed_cd_readahead", "1"},
-    {"pcsx_rearmed_exception_emulation", "enabled"},
-    {"pcsx_rearmed_gteregsunneeded", "enabled"},
-    {"pcsx_rearmed_neon_enhancement_tex_adj_v2", "disabled"},
-    {"pcsx_rearmed_nostalls", "enabled"},
-    {"pcsx_rearmed_noxadecoding", "enabled"},
-    {"pcsx_rearmed_spu_thread", "enabled"},
     {"pcsx_rearmed_vibration", "disabled"},
 #elif defined(MEDNAFEN_VB_BUILD)
     {"vb_color_mode", "black & green"},


### PR DESCRIPTION
This PR updates the PCSX ReARMed core to the latest revision which has significantly improved performance after the most recent work that was done by notaz. Almost all games should be playable at full speed without speedhacks or frame skipping! It also changes the default settings for that core to be much more stable, removing now unnecessary speedhacks and also disabling threaded spu which now causes hangs. Most settings are left at the core defaults now - BIOS will be "Auto" so it will default to HLE only when none is present. I wasn't sure about 

`{"pcsx_rearmed_cd_readahead", "1"},`

the default in the core and RetroArch is 12, but it doesn't seem to cause issues and I wasn't sure why you put it there so I left it. Anyway now we can have full speed PSX on native Vita (instead of e.g. Adrenaline) with right analog stick and good shaders, cheers!